### PR TITLE
fix(lazy-loading): fix a bug that make pages crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0"
     />
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache"
+    />
     <title>FX Clash Stats</title>
   </head>
   <body class="bg-white dark:bg-gray-800">

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -9,6 +9,10 @@ const ErrorPage = () => {
 
   console.log('error >> ', error);
 
+  if ((error as TypeError).message.includes('Failed to fetch dynamically imported module')) {
+    window.location.reload();
+  }
+
   Sentry.captureException(error);
 
   return (


### PR DESCRIPTION
the crash appens when the app tries to import a file from an old build, this is because of the lazy loading. More info here https://github.com/vitejs/vite/issues/11804