### PR TITLE
fix(typos): update driver stats

### DIFF
--- a/scripts/generateAssets/drivers/drivers.ts
+++ b/scripts/generateAssets/drivers/drivers.ts
@@ -2353,7 +2353,7 @@ const DRIVERS: Driver[] = [
         defending: 55,
         qualifying: 59,
         raceStart: 49,
-        tireManagement: 69,
+        tireManagement: 60,
       },
       {
         level: 7,


### PR DESCRIPTION
Seems like a typo, in the game he has 60 tire management

![Screenshot_2023-09-08-10-49-24-20_32cde548097e4261441d1f1c1ff9159a](https://github.com/ruiaraujo012/fx-clash-stats-web/assets/48203045/0d497790-3e2b-4b3e-afa9-6b82f9d7ca4b)
